### PR TITLE
refactor: remove Python 2 remnants

### DIFF
--- a/proc.py
+++ b/proc.py
@@ -222,10 +222,10 @@ def command(
     if inherit_env is None:
         inherit_env = True
 
-    merged_env = env
     if inherit_env:
-        if env is not None:
-            merged_env = dict(os.environ, **env)
+        merged_env = dict(os.environ, **(env or {}))
+    else:
+        merged_env = env
 
     if isinstance(cmd, (list, tuple)):
         cmds = cmd

--- a/proc.py
+++ b/proc.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# coding: utf-8
 
 import errno
 import io
@@ -22,13 +21,7 @@ except ModuleNotFoundError:
 
 logger = logging.getLogger(__name__)
 
-defenc = None
-
-if hasattr(sys, "getfilesystemencoding"):
-    defenc = sys.getfilesystemencoding()
-
-if defenc is None:
-    defenc = sys.getdefaultencoding()
+defenc = sys.getfilesystemencoding() or sys.getdefaultencoding()
 
 
 class CalledProcessError(subprocess.CalledProcessError):

--- a/proc.py
+++ b/proc.py
@@ -396,9 +396,8 @@ def start_process(cmd, target, env, *args):
         try:
             os.execlpe(cmd, cmd, target, *args)
         except Exception:
-            # we can do nothing when error in execlpe
-            # don't logger here, logger need get GIL lock
-            # children process may dead lock
-            pass
+            # Can't use logger here - GIL deadlock risk in forked child.
+            # Exit with non-zero code to signal failure to parent.
+            os._exit(1)
     else:
         _waitpid(pid)

--- a/proc.py
+++ b/proc.py
@@ -13,17 +13,11 @@ import time
 try:
     import pty
 except ModuleNotFoundError:
-    #  Windows does not support pty:
-    #      import pty
-    #  pty.py:12: in <module>
-    #      import tty
-    #  tty.py:5: in <module>
-    #      from termios import *
-    #  ModuleNotFoundError: No module named 'termios'
-    class pty(object):
-        @classmethod
+    # Windows does not support pty (no termios module)
+    class pty:
+        @staticmethod
         def openpty():
-            raise Exception("No pty support on this platform")
+            raise NotImplementedError("PTY not supported on this platform")
 
 
 logger = logging.getLogger(__name__)

--- a/proc.py
+++ b/proc.py
@@ -240,11 +240,6 @@ def command(
         else:
             ioopt = {}
 
-    textopt = {}
-    # since 3.7 there is a text arg
-    if sys.version_info.minor >= 7:
-        textopt["text"] = text
-
     subproc = subprocess.Popen(
         cmds,
         bufsize=bufsize,
@@ -261,7 +256,7 @@ def command(
         shell=shell,
         start_new_session=start_new_session,
         startupinfo=startupinfo,
-        **textopt,
+        text=text,
         universal_newlines=universal_newlines,
         **ioopt,
     )

--- a/proc.py
+++ b/proc.py
@@ -295,8 +295,6 @@ def command(
             subproc.wait()
             raise
 
-        subproc.wait()
-
         if out is None:
             out = ""
         if err is None:

--- a/proc.py
+++ b/proc.py
@@ -57,20 +57,7 @@ class CalledProcessError(subprocess.CalledProcessError):
     """
 
     def __init__(self, returncode, out, err, cmd, options):
-        if sys.version_info.major == 3 and sys.version_info.minor >= 5:
-            super(CalledProcessError, self).__init__(
-                returncode,
-                cmd,
-                output=out,
-                stderr=err,
-            )
-        else:
-            # python 3.4 has no stderr arg
-            super(CalledProcessError, self).__init__(
-                returncode,
-                cmd,
-                output=out,
-            )
+        super().__init__(returncode, cmd, output=out, stderr=err)
 
         self.returncode = returncode
         self.stdout = out

--- a/test/test_proc.py
+++ b/test/test_proc.py
@@ -222,6 +222,22 @@ class TestProc(unittest.TestCase):
         self.assertEqual(0, returncode)
         self.assertEqual("None\n", out, "no PATH inherited")
 
+    def test_inherit_env_default(self):
+        # When inherit_env=True (default) and env=None (default),
+        # the subprocess should inherit the current environment.
+        returncode, out, err = k3proc.command(
+            sys.executable,
+            "-c",
+            'import os; print(os.environ.get("PATH", "NOT_FOUND"))',
+        )
+        dd("returncode:", returncode)
+        dd("out:", out)
+        dd("err:", err)
+
+        self.assertEqual(0, returncode)
+        self.assertNotEqual("NOT_FOUND\n", out, "PATH should be inherited by default")
+        self.assertEqual(os.environ.get("PATH") + "\n", out)
+
     def test_input(self):
         returncode, out, err = k3proc.command("python", "read_fd.py", "0", input="abc", cwd=this_base)
         dd("returncode:", returncode)


### PR DESCRIPTION

## Changelog

##### refactor: remove Python 2 remnants
Changes:
- Remove '# coding: utf-8' declaration (unnecessary in Python 3)
- Simplify defenc initialization (hasattr check unnecessary in Python 3.9+)


##### perf: optimize _close_fds() using /proc/self/fd or /dev/fd
Instead of iterating through all possible FDs (up to 65536), first try
to get the list of actually open FDs via /proc/self/fd (Linux) or
/dev/fd (macOS). Falls back to brute-force iteration if neither works.

This significantly reduces the number of close() syscalls needed.


##### fix: exit with non-zero code when execlpe fails in start_process
Previously, if execlpe failed in the forked child, the process silently
exited with code 0, misleading the parent about success. Now it exits
with code 1 to properly signal failure.

Note: Cannot use logger due to GIL deadlock risk in forked child.


##### refactor: improve pty fallback stub for Windows
Changes:
- Use NotImplementedError instead of generic Exception
- Fix @classmethod to @staticmethod (method has no cls parameter)
- Simplify comment and class definition


##### refactor: remove redundant subproc.wait() after communicate()
The communicate() method already waits for the process to terminate,
so the explicit wait() call afterwards is redundant.

Note: The None checks for out/err are kept as they handle capture=False mode.


##### refactor: remove Python 3.7 version check for text parameter
The package requires Python 3.9+, so the version check for Python 3.7
text parameter in subprocess.Popen is dead code.

Changes:
- Remove textopt dict and version check
- Pass text parameter directly to Popen


##### refactor: remove Python 3.5 version check in CalledProcessError
The package requires Python 3.9+, so the version check for Python 3.5
stderr parameter in subprocess.CalledProcessError is dead code.

Changes:
- Simplify CalledProcessError.__init__ to always pass stderr param
- Use super() instead of explicit class name


##### fix: correct env inheritance when env=None
When inherit_env=True (default) and env=None (default), the subprocess
should inherit the current environment. The previous logic only merged
environments when env was explicitly provided, leaving merged_env as None.

Changes:
- Fix env inheritance logic to always inherit when `inherit_env=True`
- Add `test_inherit_env_default` test to verify the fix

---

- Bug Fix
- Improvement
